### PR TITLE
Fix compile errors when using this package with a pre-2024 version of Wwise

### DIFF
--- a/Runtime/AkAddressableBankManager.cs
+++ b/Runtime/AkAddressableBankManager.cs
@@ -173,8 +173,8 @@ namespace AK.Wwise.Unity.WwiseAddressables
 						AkUnitySoundEngine.PrepareEvent(AkPreparationType.Preparation_Unload, new string[] { Bank.name }, 1);
 						AkUnitySoundEngine.UnloadBank(Bank.soundbankId, System.IntPtr.Zero, Bank.bankType);
 #else
-						AkSoundEngine.PrepareEvent(AkPreparationType.Preparation_Unload, new string[] { bank.name }, 1);
-						AkSoundEngine.UnloadBank(bank.soundbankId, System.IntPtr.Zero, bank.bankType);
+						AkSoundEngine.PrepareEvent(AkPreparationType.Preparation_Unload, new string[] { Bank.name }, 1);
+						AkSoundEngine.UnloadBank(Bank.soundbankId, System.IntPtr.Zero, Bank.bankType);
 #endif
 					}
 					else
@@ -182,7 +182,7 @@ namespace AK.Wwise.Unity.WwiseAddressables
 #if WWISE_2024_OR_LATER
 						AkUnitySoundEngine.UnloadBank(Bank.soundbankId, System.IntPtr.Zero);
 #else
-						AkSoundEngine.UnloadBank(bank.soundbankId, System.IntPtr.Zero);
+						AkSoundEngine.UnloadBank(Bank.soundbankId, System.IntPtr.Zero);
 #endif
 					}
 				}


### PR DESCRIPTION
We are using Wwise 2023 and this package would not compile with the following errors:
```
Library/PackageCache/com.audiokinetic.wwise.addressables@9ea57a5b65/Runtime/AkAddressableBankManager.cs(176,87): error CS0103: The name 'bank' does not exist in the current context
Library/PackageCache/com.audiokinetic.wwise.addressables@9ea57a5b65/Runtime/AkAddressableBankManager.cs(177,32): error CS0103: The name 'bank' does not exist in the current context
Library/PackageCache/com.audiokinetic.wwise.addressables@9ea57a5b65/Runtime/AkAddressableBankManager.cs(177,70): error CS0103: The name 'bank' does not exist in the current context
Library/PackageCache/com.audiokinetic.wwise.addressables@9ea57a5b65/Runtime/AkAddressableBankManager.cs(185,32): error CS0103: The name 'bank' does not exist in the current context
```

This PR fixes the compilation errors, but I have not yet been able to functional testing with Wwise 2023.