### PR TITLE
Fix WebGL build error

### DIFF
--- a/Runtime/AkAddressableBankManager.cs
+++ b/Runtime/AkAddressableBankManager.cs
@@ -487,7 +487,7 @@ namespace AK.Wwise.Unity.WwiseAddressables
 #if UNITY_WEBGL && !UNITY_EDITOR
 			// On WebGL, we MUST load asynchronously in order to yield back to the browser.
 			// Failing to do so will result in the thread blocking forever and the asset will never be loaded.
-			soundBankAsset = await asyncHandle.Task;
+			soundBankAsset = (WwiseSoundBankAsset)await asyncHandle.Task;
 #else
 			if (loadAsync)
 			{


### PR DESCRIPTION
WebGL builds failed with this error message:
```error CS0266: Cannot implicitly convert type 'object' to 'AK.Wwise.Unity.WwiseAddressables.WwiseSoundBankAsset'. An explicit conversion exists (are you missing a cast?)```

Adding the missing cast solved the issue.

Tested with a project using Unity 2022.3.59f1 and Wwise 2023.1.14.