### PR TITLE
WG-80296 The Wwise Unity Addressables is not backward compatible

### DIFF
--- a/Editor/AddressableSymbolDefiner.cs
+++ b/Editor/AddressableSymbolDefiner.cs
@@ -1,15 +1,22 @@
 using System;
 using System.Linq;
+using System.Reflection;
 using UnityEditor;
 
 [InitializeOnLoad]
 public static class AddressableSymbolDefiner
 {
     private const string CurrentVersion = "WWISE_ADDRESSABLES_24_1_OR_LATER";
+    private static string _currentAdapterVersion = "";
 
     static AddressableSymbolDefiner()
     {
-
+        AkUnitySoundEngineInitialization.Instance.initializationDelegate += AddAdapterSymbol;
+        
+        //Clean up function we subscribe to in order to properly unsubscribe from the initializationDelegate on domain reload or editor shutdown
+        AssemblyReloadEvents.beforeAssemblyReload += Cleanup;
+        EditorApplication.quitting += Cleanup;
+        
         if (PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Contains(CurrentVersion))
         {
             return;
@@ -17,12 +24,95 @@ public static class AddressableSymbolDefiner
 #if !WWISE_2024_OR_LATER
         return;
 #endif
-        foreach (BuildTargetGroup targetGroup in Enum.GetValues(typeof(BuildTargetGroup)))
+        foreach (BuildTargetGroup targetGroup in GetNonObsoleteTargetGroups())
         {
-            if (targetGroup != BuildTargetGroup.Unknown)
+            if (targetGroup == BuildTargetGroup.Unknown)
             {
-                AddDefineSymbols(targetGroup);
+                continue;
             }
+            AddDefineSymbols(targetGroup);
+        }
+    }
+    
+    private static void Cleanup()
+    {
+        AkUnitySoundEngineInitialization.Instance.initializationDelegate -= AddAdapterSymbol;
+        AssemblyReloadEvents.beforeAssemblyReload -= Cleanup;
+        EditorApplication.quitting -= Cleanup;
+    }
+
+    private static void SetCurrentAdapterVersion()
+    {
+        string wwiseVersion = AkUnitySoundEngine.WwiseVersion;
+        int firstSpaceIndex = wwiseVersion.IndexOf(' ');
+        if (firstSpaceIndex < 0)
+        {
+            return;
+        }
+        string shortWwiseVersion = wwiseVersion.Substring(0, firstSpaceIndex);
+        string[] versionParts = shortWwiseVersion.Split('.');
+        int currentMinor = 0;
+        
+        if (int.TryParse(versionParts[2], out currentMinor))
+        {
+            if (currentMinor is > 7 and < 10)
+            {
+                _currentAdapterVersion = "ADDRESSABLES_API_BREAK_AK_UTILITIES";
+            }
+            else
+            {
+                _currentAdapterVersion = "ADDRESSABLES_API_DEFAULT";
+            }
+        }
+    }
+    
+    public static BuildTargetGroup[] GetNonObsoleteTargetGroups()
+    {
+        Type enumType = typeof(BuildTargetGroup);
+
+        return Enum.GetValues(enumType).Cast<BuildTargetGroup>().Where(targetGroup =>
+        {
+            string name = targetGroup.ToString();
+            MemberInfo member = enumType.GetMember(name).FirstOrDefault();
+
+            if (member == null) return false; 
+
+            return member.GetCustomAttribute<ObsoleteAttribute>() == null;
+        }).ToArray();
+    }
+
+    private static void AddAdapterSymbol()
+    {
+        if (_currentAdapterVersion == "")
+        {
+            SetCurrentAdapterVersion();
+        }
+        if (PlayerSettings.GetScriptingDefineSymbolsForGroup(BuildTargetGroup.Standalone).Contains(_currentAdapterVersion))
+        {
+            return;
+        }
+        
+        foreach (BuildTargetGroup targetGroup in GetNonObsoleteTargetGroups())
+        {
+#if UNITY_5_4_OR_NEWER
+            if (targetGroup == BuildTargetGroup.Unknown)
+            {
+                continue;
+            }
+#endif
+            string currentDefines = PlayerSettings.GetScriptingDefineSymbolsForGroup(targetGroup);
+            var currentDefineList = currentDefines.Split(';').ToList();
+
+            const string wwiseAddressablePrefix = "ADDRESSABLES_API";
+            currentDefineList.RemoveAll(define => define.StartsWith(wwiseAddressablePrefix));
+
+            if (!string.IsNullOrEmpty(_currentAdapterVersion))
+            {
+                currentDefineList.Add(_currentAdapterVersion);
+            }
+
+            string newDefinesString = string.Join(";", currentDefineList.Distinct());
+            PlayerSettings.SetScriptingDefineSymbolsForGroup(targetGroup, newDefinesString);
         }
     }
 

--- a/Editor/AkAddressablesEditorSettings.cs
+++ b/Editor/AkAddressablesEditorSettings.cs
@@ -214,11 +214,11 @@ namespace AK.Wwise.Unity.WwiseAddressables
 							UnityEditor.EditorGUILayout.SelectableLabel(settings.MetadataPath, Styles.TextField, UnityEngine.GUILayout.Height(17));
 							if (Ellipsis())
 							{
-								var OpenInPath = System.IO.Path.GetDirectoryName(AkUtilities.GetFullPath(UnityEngine.Application.dataPath, settings.MetadataPath));
+								var OpenInPath = System.IO.Path.GetDirectoryName(WwiseAddressableAdapter.Instance.GetFullPath(UnityEngine.Application.dataPath, settings.MetadataPath));
 								var MetadataPathNew = UnityEditor.EditorUtility.OpenFolderPanel("Select your metadata Project", OpenInPath, "WwiseAddressableMetadata");
 								if (MetadataPathNew.Length != 0)
 								{
-									settings.MetadataPath = AkUtilities.MakeRelativePath(UnityEngine.Application.dataPath, MetadataPathNew);
+									settings.MetadataPath = WwiseAddressableAdapter.Instance.MakeRelativePath(UnityEngine.Application.dataPath, MetadataPathNew);
 									changed = true;
 								}
 							}

--- a/Editor/AkAddressablesEditorUtilities.cs
+++ b/Editor/AkAddressablesEditorUtilities.cs
@@ -417,7 +417,7 @@ namespace AK.Wwise.Unity.WwiseAddressables
 			{
 				return await ExecuteUpdate(platformName, newBankName, language, type);
 			}
-			if (!isJsonFileMissing && AkUtilities.IsAutoBankEnabled())
+			if (!isJsonFileMissing && WwiseAddressableAdapter.Instance.IsAutoBankEnabled())
 			{
 				WwiseProjectDatabase.SoundBankDirectoryUpdated += RefreshIsJsonFileMissing;
 				isJsonFileMissing = true;

--- a/Runtime/AkAddressablesSoundEngineInitialization.cs
+++ b/Runtime/AkAddressablesSoundEngineInitialization.cs
@@ -28,32 +28,7 @@ public class AkAddressablesSoundEngineInitialization : AkSoundEngineInitializati
 {
 	public static void ResetInstance()
 	{
-		if(m_Instance != null)
-		{
-			InitializationDelegate copyInitialize = m_Instance.initializationDelegate;
-#if WWISE_ADDRESSABLES_24_1_OR_LATER
-			ReInitializationDelegate copyReInitialize = m_Instance.reInitializationDelegate;
-#endif
-			TerminationDelegate copyTerminate = m_Instance.terminationDelegate;
-#if WWISE_2024_OR_LATER
-			m_Instance = new AkUnityAddressablesSoundEngineInitialization();
-#else
-			m_Instance = new AkAddressablesSoundEngineInitialization();
-#endif
-			m_Instance.initializationDelegate = copyInitialize;
-#if WWISE_ADDRESSABLES_24_1_OR_LATER
-			m_Instance.reInitializationDelegate = copyReInitialize;
-#endif
-			m_Instance.terminationDelegate = copyTerminate;
-		}
-		else
-		{
-#if WWISE_2024_OR_LATER
-			m_Instance = new AkUnityAddressablesSoundEngineInitialization();
-#else
-			m_Instance = new AkAddressablesSoundEngineInitialization();
-#endif
-		}
+		WwiseAddressableAdapter.Instance.ResetInstance(m_Instance);
 	}
 
 	protected override void LoadInitBank()

--- a/Runtime/AkWwiseAddressablesInitializationSettings.cs
+++ b/Runtime/AkWwiseAddressablesInitializationSettings.cs
@@ -95,7 +95,7 @@ namespace AK.Wwise.Unity.WwiseAddressables
 			}
 
 			var createdAsset = CreateInstance<AkWwiseAddressablesInitializationSettings>();
-			AkUtilities.CreateFolder(AkWwiseEditorSettings.WwiseScriptableObjectRelativePath);
+			WwiseAddressableAdapter.Instance.CreateFolderFromAkUtilities(AkWwiseEditorSettings.WwiseScriptableObjectRelativePath);
 			UnityEditor.AssetDatabase.CreateAsset(createdAsset, path);
 			return createdAsset;
 		}

--- a/Runtime/WwiseAddressableAdapter.meta
+++ b/Runtime/WwiseAddressableAdapter.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 846db1c157fe4615a68073ac59f3f821
+timeCreated: 1758810940

--- a/Runtime/WwiseAddressableAdapter/IWwiseAddressableAdapter.cs
+++ b/Runtime/WwiseAddressableAdapter/IWwiseAddressableAdapter.cs
@@ -1,0 +1,8 @@
+﻿public interface IWwiseAddressableAdapter
+{
+    public void ResetInstance(AkUnitySoundEngineInitialization instance);
+    public void CreateFolderFromAkUtilities(string folderPath);
+    public bool IsAutoBankEnabled();
+    public string GetFullPath(string basePath, string relativePath);
+    public string MakeRelativePath(string fromPath, string toPath);
+}

--- a/Runtime/WwiseAddressableAdapter/IWwiseAddressableAdapter.cs.meta
+++ b/Runtime/WwiseAddressableAdapter/IWwiseAddressableAdapter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: dc8d099b94e9492f82b7fc3f49eea13f
+timeCreated: 1758750977

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter.cs
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter.cs
@@ -1,0 +1,16 @@
+﻿using UnityEngine;
+
+public class WwiseAddressableAdapter
+{
+    private static IWwiseAddressableAdapter _instance;
+    public static IWwiseAddressableAdapter Instance {
+        get
+        {
+            if (_instance == null)
+            {
+                _instance = WwiseAddressableAdapterFactory.CreateManager();
+            }
+            return _instance;
+        }
+    }
+}

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter.cs.meta
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 84a9eee9fd6f4a58ba65b269e293c7b0
+timeCreated: 1758750799

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapterFactory.cs
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapterFactory.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Reflection;
+public static class WwiseAddressableAdapterFactory
+{
+    public static IWwiseAddressableAdapter CreateManager()
+    {
+#if ADDRESSABLES_API_DEFAULT
+        return new WwiseAddressableAdapter_Default();
+#else
+        return new WwiseAddressableAdapter_Null();
+#endif
+    }
+}

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapterFactory.cs.meta
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapterFactory.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4f4454f4bd564fe4b67ddddf8c358d67
+timeCreated: 1758750927

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Default.cs
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Default.cs
@@ -1,0 +1,42 @@
+﻿#if ADDRESSABLES_API_DEFAULT
+public class WwiseAddressableAdapter_Default : IWwiseAddressableAdapter
+{
+        public void ResetInstance(AkUnitySoundEngineInitialization instance)
+        {
+            if(instance != null)
+            {
+                AkUnitySoundEngineInitialization.InitializationDelegate copyInitialize = instance.initializationDelegate;
+                AkUnitySoundEngineInitialization.ReInitializationDelegate copyReInitialize = instance.reInitializationDelegate;
+                AkUnitySoundEngineInitialization.TerminationDelegate copyTerminate = instance.terminationDelegate;
+                instance = new AkUnityAddressablesSoundEngineInitialization();
+                instance.initializationDelegate = copyInitialize;
+                instance.reInitializationDelegate = copyReInitialize;
+                instance.terminationDelegate = copyTerminate;
+            }
+            else
+            {
+                instance = new AkUnityAddressablesSoundEngineInitialization();
+            }
+        }
+
+        public void CreateFolderFromAkUtilities(string folderPath)
+        {
+            AkUtilities.CreateFolder(AkWwiseEditorSettings.WwiseScriptableObjectRelativePath);
+        }
+
+        public bool IsAutoBankEnabled()
+        {
+            return AkUtilities.IsAutoBankEnabled();
+        }
+
+        public string GetFullPath(string basePath, string relativePath)
+        {
+            return AkUtilities.GetFullPath(basePath, relativePath);
+        }
+
+        public string MakeRelativePath(string fromPath, string toPath)
+        {
+            return AkUtilities.MakeRelativePath(fromPath, toPath);
+        }
+}
+#endif

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Default.cs.meta
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Default.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 4037f1cb35d946fc80aa24022a5b959f
+timeCreated: 1758750771

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Null.cs
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Null.cs
@@ -1,0 +1,58 @@
+﻿using System.Runtime.CompilerServices;
+
+public class WwiseAddressableAdapter_Null : IWwiseAddressableAdapter
+{
+    private static bool _missMatchVersionLog = false;
+    private static string currentIntegrationVersion;
+
+    public WwiseAddressableAdapter_Null()
+    {
+        string wwiseVersion = AkUnitySoundEngine.WwiseVersion;
+        int firstSpaceIndex = wwiseVersion.IndexOf(' ');
+        if (firstSpaceIndex < 0)
+        {
+            return;
+        }
+        string shortWwiseVersion = wwiseVersion.Substring(2, firstSpaceIndex-2);
+        currentIntegrationVersion = shortWwiseVersion;
+        LogMissMatchVersion();
+    }
+
+    private static void LogMissMatchVersion()
+    {
+        UnityEngine.Debug.LogError($"The current Wwise Unity Addressables package version is not compatible with the installed integration. Please upgrade to the {currentIntegrationVersion} Wwise Addressables package.");
+    }
+    
+    private static void LogNotImplemented([CallerMemberName] string methodName = null)
+    {
+        UnityEngine.Debug.LogError($"Wwise Addressables function {methodName} is not implemented. Have you updated your Wwise Unity Addressables package?");
+    }
+
+    public void ResetInstance(AkUnitySoundEngineInitialization instance)
+    {
+        LogNotImplemented();
+    }
+
+    public void CreateFolderFromAkUtilities(string folderPath)
+    {
+        LogNotImplemented();
+    }
+
+    public bool IsAutoBankEnabled()
+    {
+        LogNotImplemented();
+        return false;
+    }
+
+    public string GetFullPath(string basePath, string relativePath)
+    {
+        LogNotImplemented();
+        return string.Empty;
+    }
+
+    public string MakeRelativePath(string fromPath, string toPath)
+    {
+        LogNotImplemented();
+        return string.Empty;
+    }
+}

--- a/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Null.cs.meta
+++ b/Runtime/WwiseAddressableAdapter/WwiseAddressableAdapter_Null.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b72b63f76f464b299cab909b8b912fa3
+timeCreated: 1758749099


### PR DESCRIPTION
A backward compatibility patch to make this version of the package able to compile with newer versions of the integration